### PR TITLE
Fix setup-helper usage

### DIFF
--- a/call-with-sqlite3-connection.release-info
+++ b/call-with-sqlite3-connection.release-info
@@ -3,3 +3,4 @@
 (release "0.1")
 (release "0.1.1")
 (release "0.1.2")
+(release "0.1.3")

--- a/call-with-sqlite3-connection.setup
+++ b/call-with-sqlite3-connection.setup
@@ -2,4 +2,4 @@
 
 (setup-shared-extension-module
  'call-with-sqlite3-connection
- (extension-version 0.1))
+ (extension-version "0.1.3"))

--- a/call-with-sqlite3-connection.setup
+++ b/call-with-sqlite3-connection.setup
@@ -1,4 +1,4 @@
-(include "setup-helper")
+(use setup-helper-mod)
 
 (setup-shared-extension-module
  'call-with-sqlite3-connection


### PR DESCRIPTION
[Today's salmonella build](https://salmonella-linux-x86-64.call-cc.org/master-debugbuild/gcc/linux/x86-64/2016/09/03/yesterday-diff/log2/install/call-with-sqlite3-connection.html) shows that call-with-sqlite3-connection fails to install with setup-helper 2.0.

Using `(include "setup-helper")` to load setup-helper is deprecated, and has been for a very long time. See also [this thread on chicken-users](http://lists.gnu.org/archive/html/chicken-users/2016-09/msg00004.html)

This PR simply uses the new style `(use setup-helper-mod)` and adds a 0.1.3 release. It also fixes the version in the `.setup` file. Please check if the tag is included in the pull request (I don't know enough about github to know if this is done or not).
